### PR TITLE
Fixing support for map[string]struct{} generation to dictionary<strin…

### DIFF
--- a/Docker.DotNet/Models/Config.Generated.cs
+++ b/Docker.DotNet/Models/Config.Generated.cs
@@ -25,7 +25,7 @@ namespace Docker.DotNet.Models
         public bool AttachStderr { get; set; }
 
         [DataMember(Name = "ExposedPorts")]
-        public ISet<string> ExposedPorts { get; set; }
+        public IDictionary<string, object> ExposedPorts { get; set; }
 
         [DataMember(Name = "PublishService")]
         public string PublishService { get; set; }
@@ -52,7 +52,7 @@ namespace Docker.DotNet.Models
         public string Image { get; set; }
 
         [DataMember(Name = "Volumes")]
-        public ISet<string> Volumes { get; set; }
+        public IDictionary<string, object> Volumes { get; set; }
 
         [DataMember(Name = "WorkingDir")]
         public string WorkingDir { get; set; }

--- a/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -61,7 +61,7 @@ namespace Docker.DotNet.Models
         public bool AttachStderr { get; set; }
 
         [DataMember(Name = "ExposedPorts")]
-        public ISet<string> ExposedPorts { get; set; }
+        public IDictionary<string, object> ExposedPorts { get; set; }
 
         [DataMember(Name = "PublishService")]
         public string PublishService { get; set; }
@@ -88,7 +88,7 @@ namespace Docker.DotNet.Models
         public string Image { get; set; }
 
         [DataMember(Name = "Volumes")]
-        public ISet<string> Volumes { get; set; }
+        public IDictionary<string, object> Volumes { get; set; }
 
         [DataMember(Name = "WorkingDir")]
         public string WorkingDir { get; set; }


### PR DESCRIPTION
…g, object> so it doesnt fail when empty

Signed-off-by: Justin Terry <juterry@microsoft.com>